### PR TITLE
Fix a couple of tracebacks due to signed BSON integer values

### DIFF
--- a/lib/cuckoo/common/netlog.py
+++ b/lib/cuckoo/common/netlog.py
@@ -156,8 +156,8 @@ class BsonParser(object):
 
             if apiname == "__process__":
                 # Special new process message from cuckoomon.
-                timelow = argdict["TimeLow"]
-                timehigh = argdict["TimeHigh"]
+                timelow = argdict["TimeLow"] & 0xFFFFFFFF
+                timehigh = argdict["TimeHigh"] & 0xFFFFFFFF
                 # FILETIME is 100-nanoseconds from 1601 :/
                 vmtimeunix = (timelow + (timehigh << 32))
                 vmtimeunix = vmtimeunix / 10000000.0 - 11644473600

--- a/lib/cuckoo/common/utils.py
+++ b/lib/cuckoo/common/utils.py
@@ -1588,7 +1588,9 @@ def default_converter(v):
     # Fix signed ints (bson is kind of limited there).
     if type(v) is int:
         return v & 0xFFFFFFFF
-    elif type(v) is long:
+    # Need to account for subclasses since pymongo's bson module
+    # uses 'bson.int64.Int64' class for 64-bit values.
+    elif issubclass(type(v), long):
         if v & 0xFFFFFFFF00000000:
             return v & 0xFFFFFFFFFFFFFFFF
         else:


### PR DESCRIPTION
Fix a couple of tracebacks due to signed integer values being returned by the BSON decoder.