### PR TITLE
A couple of fixes

### DIFF
--- a/modules/machinery/vsphere.py
+++ b/modules/machinery/vsphere.py
@@ -85,14 +85,10 @@ class vSphere(Machinery):
         # Workaround for PEP-0476 issues in recent Python versions
         if self.options.vsphere.unverified_ssl:
             import ssl
-
-            try:
-                _create_ssl_context = ssl._create_unverified_context
-            except AttributeError:
-                pass
-            else:
-                log.warn("Turning off SSL certificate verification!")
-                ssl._create_default_https_context = _create_ssl_context
+            sslContext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            sslContext.verify_mode = ssl.CERT_NONE
+            self.connect_opts["sslContext"] = sslContext
+            log.warn("Turning off SSL certificate verification!")
 
         # Check that a snapshot is configured for each machine
         # and that it was taken in a powered-on state
@@ -127,8 +123,7 @@ class vSphere(Machinery):
             raise
 
         except Exception as e:
-            raise CuckooCriticalError("Couldn't connect to vSphere host: {0}"
-                                      .format(e))
+            raise CuckooCriticalError("Couldn't connect to vSphere host")
 
         super(vSphere, self)._initialize_check()
 

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -843,9 +843,18 @@ def flowtuple_from_raw(raw, linktype=1):
         sip, dip = socket.inet_ntoa(ip.src), socket.inet_ntoa(ip.dst)
         proto = ip.p
 
-        if proto == dpkt.ip.IP_PROTO_TCP or proto == dpkt.ip.IP_PROTO_UDP:
+        if proto == dpkt.ip.IP_PROTO_TCP:
             l3 = ip.data
+            if not isinstance(l3, dpkt.tcp.TCP):
+                l3 = dpkt.tcp.TCP(l3)
             sport, dport = l3.sport, l3.dport
+
+        elif proto == dpkt.ip.IP_PROTO_UDP:
+            l3 = ip.data
+            if not isinstance(l3, dpkt.udp.UDP):
+                l3 = dpkt.udp.UDP(l3)
+            sport, dport = l3.sport, l3.dport
+
         else:
             sport, dport = 0, 0
 

--- a/modules/processing/network.py
+++ b/modules/processing/network.py
@@ -842,17 +842,12 @@ def flowtuple_from_raw(raw, linktype=1):
     if isinstance(ip, dpkt.ip.IP):
         sip, dip = socket.inet_ntoa(ip.src), socket.inet_ntoa(ip.dst)
         proto = ip.p
+        l3 = ip.data
 
-        if proto == dpkt.ip.IP_PROTO_TCP:
-            l3 = ip.data
-            if not isinstance(l3, dpkt.tcp.TCP):
-                l3 = dpkt.tcp.TCP(l3)
+        if proto == dpkt.ip.IP_PROTO_TCP and isinstance(l3, dpkt.tcp.TCP):
             sport, dport = l3.sport, l3.dport
 
-        elif proto == dpkt.ip.IP_PROTO_UDP:
-            l3 = ip.data
-            if not isinstance(l3, dpkt.udp.UDP):
-                l3 = dpkt.udp.UDP(l3)
+        elif proto == dpkt.ip.IP_PROTO_UDP and isinstance(l3, dpkt.udp.UDP):
             sport, dport = l3.sport, l3.dport
 
         else:


### PR DESCRIPTION
1) Fix traceback in NetworkAnalysis plugin when sorting pcaps that contain incomplete packets:

Traceback (most recent call last):
  File "/opt/sandbox/cuckoo-modified/lib/cuckoo/core/plugins.py", line 197, in process
    data = current.run()
  File "/opt/sandbox/cuckoo-modified/modules/processing/network.py", line 700, in run
    sort_pcap(self.pcap_path, sorted_path)
  File "/opt/sandbox/cuckoo-modified/modules/processing/network.py", line 834, in sort_pcap
    batch_sort(inc, outpath, output_class=lambda path: SortCap(path, linktype=inc.linktype))
  File "/opt/sandbox/cuckoo-modified/modules/processing/network.py", line 751, in batch_sort
    current_chunk = list(islice(input_iterator, buffer_size))
  File "/opt/sandbox/cuckoo-modified/modules/processing/network.py", line 819, in next
    sip, dip, sport, dport, proto = flowtuple_from_raw(raw, self.linktype)
  File "/opt/sandbox/cuckoo-modified/modules/processing/network.py", line 848, in flowtuple_from_raw
    sport, dport = l3.sport, l3.dport
AttributeError: 'str' object has no attribute 'sport'

2) Implement proper SSL certificate verification bypass in vSphere machinery module, which became available in latest pyvmomi vSphere Python SDK (version 6.0.0).  The previous workaround disabled SSL certificate verification globally in the entire process, which is not a desirable solution.  With this change, the SSL certificate verification will be disabled only for connections from the machinery module to the vSphere host.