### PR TITLE
Properly initialize the feed dict

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -670,6 +670,7 @@ class GetFeeds(object):
 
     def __init__(self, results):
         self.results = results
+        self.results["feeds"] = dict()
 
     def process(self, feed):
         """Process modules with either downloaded data directly, or by
@@ -694,7 +695,7 @@ class GetFeeds(object):
             except:
                 log.exception("Failed to run feed \"%s\"", current.name)
                 return
-        self.results["feeds"] = dict()
+
         self.results["feeds"][current.name] = current.get_feedpath()
 
     def run(self):


### PR DESCRIPTION
Previously we were initializing a new dict after processing a feed, which would only populate the feed dict with the last run feed. This wasn't apparent previously as we only had one feed.