### PR TITLE
add import re due to traceback

### DIFF
--- a/web/submission/views.py
+++ b/web/submission/views.py
@@ -8,6 +8,7 @@ import sys
 import requests
 import tempfile
 import random
+import re
 
 from django.conf import settings
 from django.shortcuts import redirect, render_to_response


### PR DESCRIPTION
Got an issue with this not being defined when this was called according to the traceback. Added in import and it works now.

 ipaddy_re = re.compile(r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")