### PR TITLE
Add Option For PassiveTotal Portal

### DIFF
--- a/conf/auxiliary.conf
+++ b/conf/auxiliary.conf
@@ -75,3 +75,6 @@ enabled = no
 
 [display_et_portal]
 enabled = yes
+
+[display_pt_portal]
+enabled = yes

--- a/web/templates/analysis/network/_dns.html
+++ b/web/templates/analysis/network/_dns.html
@@ -13,6 +13,9 @@
                 {% if config.display_et_portal %}
                 <a href="https://threatintel.proofpoint.com/search?q={{p.request}}" target="_blank">[ET]</a>
                 {% endif %}
+                {% if config.display_pt_portal %}
+                <a href="https://www.passivetotal.org/passive/{{p.request}}" target="_blank">[PT]</a>
+                {% endif %}
                 </td>
                     <td>
                         {% for a in p.answers %}
@@ -25,6 +28,9 @@
                             {% if config.display_et_portal %}
                             <a href="https://threatintel.proofpoint.com/search?q={{a.data|linebreaksbr}}" target="_blank">[ET]</a>
                             {% endif %}
+                            {% if config.display_pt_portal %}
+                            <a href="https://www.passivetotal.org/passive/{{a.data|linebreaksbr}}" target="_blank">[PT]</a>
+                            {% endif %}
                             {% if not forloop.last %}
                                 <br/>
                             {% endif %}
@@ -35,6 +41,9 @@
                         <a href="https://www.virustotal.com/en/ip-address/{{ domainlookups|get_item:p.request }}/information/">[VT]</a>
                         {% if config.display_et_portal %}
                         <a href="https://threatintel.proofpoint.com/search?q={{ domainlookups|get_item:p.request }}" target="_blank">[ET]</a>
+                        {% endif %}
+                        {% if config.display_pt_portal %}
+                        <a href="https://www.passivetotal.org/passive/{{ domainlookups|get_item:p.request }}" target="_blank">[PT]</a>
                         {% endif %}
                         {% endif %}
                     </td>

--- a/web/templates/analysis/network/_hosts.html
+++ b/web/templates/analysis/network/_hosts.html
@@ -21,6 +21,9 @@
                     {% if config.display_et_portal %}
                     <a href="https://threatintel.proofpoint.com/search?q={{host.ip}}" target="_blank">[ET]</a>
                     {% endif %}
+                    {% if config.display_pt_portal %}
+                    <a href="https://www.passivetotal.org/passive/{{host.ip}}" target="_blank">[PT]</a>
+                    {% endif %}
                     </td>
                     <td>{{host.country_name}}</td>
                 {% endif %}


### PR DESCRIPTION
Just adding the option for PassiveTotal links for Hosts and DNS like exist with VirusTotal and EmergingThreats/ProofPoint.

![image](https://cloud.githubusercontent.com/assets/15840028/12699498/32485a00-c78b-11e5-858a-d6b077fcdb5b.png)
