### PR TITLE
Set ET & PT to default to no

### DIFF
--- a/conf/auxiliary.conf
+++ b/conf/auxiliary.conf
@@ -74,7 +74,7 @@ enabled = no
 enabled = no
 
 [display_et_portal]
-enabled = yes
+enabled = no
 
 [display_pt_portal]
-enabled = yes
+enabled = no


### PR DESCRIPTION
Change the default from yes to no due to these both being commercial/registered intel solutions which not everyone will have access to for a logon.