### PR TITLE
Add a new feature to the compare view

### DIFF
--- a/web/templates/compare/both.html
+++ b/web/templates/compare/both.html
@@ -58,4 +58,170 @@ $(function () {
         </div>
     </div>
 </div>
+<hr/>
+<div class="row">
+    <h2 style="text-align: left;"> Summary Similarities</h2>
+    <div class="tabbable tabs">
+        <ul class="nav nav-pills" style="margin-bottom: 0;">
+            <li class="active"><a href="#summary_compare_files" data-toggle="tab">Accessed Files</a></li>
+            <li><a href="#summary_compare_read_files" data-toggle="tab">Read Files</a></li>
+            <li><a href="#summary_compare_write_files" data-toggle="tab">Modified Files</a></li>
+            <li><a href="#summary_compare_delete_files" data-toggle="tab">Deleted Files</a></li>
+            <li><a href="#summary_compare_keys" data-toggle="tab">Accessed Registry Keys</a></li>
+            <li><a href="#summary_compare_read_keys" data-toggle="tab">Read Registry Keys</a></li>
+            <li><a href="#summary_compare_write_keys" data-toggle="tab">Modified Registry Keys</a></li>
+            <li><a href="#summary_compare_delete_keys" data-toggle="tab">Deleted Registry Keys</a></li>
+            <li><a href="#summary_compare_resolved_apis" data-toggle="tab">Resolved APIs</a></li>
+            <li><a href="#summary_compare_executed_commands" data-toggle="tab">Executed Commands</a></li>
+            <li><a href="#summary_compare_mutexes" data-toggle="tab">Mutexes</a></li>
+            <li><a href="#summary_compare_created_services" data-toggle="tab">Created Services</a></li>
+            <li><a href="#summary_compare_started_services" data-toggle="tab">Started Services</a></li>
+        </ul>
+        <div class="tab-content">
+            <div class="tab-pane fade in active" id="summary_compare_files">
+                <div class="well mono">
+                {% if summary.files %}
+                    {% for file in summary.files %}
+                        {{file}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly accessed files.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_read_files">
+                <div class="well mono">
+                {% if summary.read_files %}
+                    {% for file in summary.read_files %}
+                        {{file}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly read files.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_write_files">
+                <div class="well mono">
+                {% if summary.write_files %}
+                    {% for file in summary.write_files %}
+                        {{file}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly written files.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_delete_files">
+                <div class="well mono">
+                {% if summary.delete_files %}
+                    {% for file in delete_files %}
+                        {{file}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly deleted files.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_keys">
+                <div class="well mono">
+                {% if summary.keys %}
+                    {% for key in summary.keys %}
+                        {{key}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly accessed registry keys.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_read_keys">
+                <div class="well mono">
+                {% if summary.read_keys %}
+                    {% for key in summary.read_keys %}
+                        {{key}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly read registry keys.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_write_keys">
+                <div class="well mono">
+                {% if summary.write_keys %}
+                    {% for key in summary.write_keys %}
+                        {{key}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly written registry keys.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_delete_keys">
+                <div class="well mono">
+                {% if summary.delete_keys %}
+                    {% for key in summary.delete_keys %}
+                        {{key}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly deleted registry keys.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_resolved_apis">
+                <div class="well mono">
+                {% if summary.resolved_apis %}
+                    {% for api in summary.resolved_apis %}
+                        {{api}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly resolved API imports.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_executed_commands">
+                <div class="well mono">
+                {% if summary.executed_commands %}
+                    {% for cmd in summary.executed_commands %}
+                        {{cmd}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly executed commands.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_mutexes">
+                <div class="well mono">
+                {% if summary.mutexes %}
+                    {% for mutex in summary.mutexes %}
+                        {{mutex}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly created mutexes.
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_created_services">
+                <div class="well mono">
+                {% if summary.created_services %}
+                    {% for service in summary.created_services %}
+                        {{service}}<br />
+                    {% endfor %}
+                {% else %}
+                No similarly created services
+                {% endif %}
+                </div>
+            </div>
+            <div class="tab-pane fade" id="summary_compare_started_services">
+                <div class="well mono">
+                {% if summary.started_services %}
+                    {% for service in summary.started_services %}
+                        {{service}}<br />
+                    {% endfor %}
+                {% else %}
+                No simiarly started services.
+                {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
Basically rip out the overview summery formatting and used it to display summary items that are identical between both analyses. This allows for easy viewing to create content in Endpoint Security software like GRR/Carbon Black/Bit9/HX/Falcon/etc.