### PR TITLE
Django 1.9 compatibility

### DIFF
--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -16,7 +16,7 @@ import zipfile
 import tempfile
 
 from django.conf import settings
-from django.core.servers.basehttp import FileWrapper
+from wsgiref.util import FileWrapper
 from django.template import RequestContext
 from django.http import HttpResponse, StreamingHttpResponse
 from django.shortcuts import redirect, render_to_response

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -12,7 +12,7 @@ import requests
 from bson import json_util
 
 from django.conf import settings
-from django.core.servers.basehttp import FileWrapper
+from wsgiref.util import FileWrapper
 from django.http import HttpResponse, StreamingHttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext


### PR DESCRIPTION
`django.core.servers.basehttp` does not contain an alias to FileWrapper anymore, this commit imports FileWrapper directly from the wsgiref.util package.

See [this commit](https://github.com/django/django/commit/bbe28496d32f76ca161f5c33787d6ad62267fcc6#diff-f6d1c75ec606389da5af6558bf57f171)