### PR TITLE
Fix for older versions of Acrobat Reader:

### DIFF
--- a/analyzer/windows/modules/packages/pdf.py
+++ b/analyzer/windows/modules/packages/pdf.py
@@ -7,7 +7,7 @@ from lib.common.abstracts import Package
 class PDF(Package):
     """PDF analysis package."""
     PATHS = [
-        ("ProgramFiles", "Adobe", "*Reader*", "Reader", "AcroRd32.exe"),
+        ("ProgramFiles", "Adobe", "*a*", "Reader", "AcroRd32.exe"),
     ]
 
     def start(self, path):


### PR DESCRIPTION
When using older versions of Acrobat Reader, the existing path cannot find AcroRd32.exe (Error: Analysis failed: The package "modules.packages.pdf" start function raised an error: Unable to find any Adobe Reader executable.)

Not found:
C:\Program Files\Adobe\Acrobat 7.0\Reader\AcroRd32.exe
Found:
C:\Program Files\Adobe\Reader 10.0\Reader\AcroRd32.exe

This update allows older versions of Acrobat Reader to be found and used.