### PR TITLE
Update resubmitexe.py

### DIFF
--- a/modules/reporting/resubmitexe.py
+++ b/modules/reporting/resubmitexe.py
@@ -27,6 +27,7 @@ from lib.cuckoo.common.exceptions import CuckooReportError
 from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.utils import to_unicode
 from lib.cuckoo.core.database import Database
+from lib.cuckoo.common.constants import CUCKOO_ROOT
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
After a recent update I started getting following error:
` ERROR: Failed to run the reporting module "ReSubmitExtractedEXE":
Traceback (most recent call last):
  File "/data/cuckoo/utils/../lib/cuckoo/core/plugins.py", line 631, in process
    current.run(self.results)
  File "/data/cuckoo/utils/../modules/reporting/resubmitexe.py", line 71, in run
    srcpath = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(report["info"]["id"]), "files", dropped['sha256'])
NameError: global name 'CUCKOO_ROOT' is not defined
`

Made this change to resbumitexe.py
Added from lib.cuckoo.common.constants import CUCKOO_ROOT 
Recent changes added statements that was looking for that constant.