### PR TITLE
Fix a traceback

### DIFF
--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -961,6 +961,7 @@ def full_memory_dump_file(request, analysis_number):
 @require_safe
 def full_memory_dump_strings(request, analysis_number):
     file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(analysis_number), "memory.dmp.strings")
+    filename = None
     if os.path.exists(file_path):
         filename = os.path.basename(file_path)
     else:


### PR DESCRIPTION
Reproducable if you have do_strings = no in memory.conf, the file will never be created and we were assuming filename gets populated.