### PR TITLE
Grab the sorted pcap hash to fix a bug in django

### DIFF
--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -1191,7 +1191,7 @@ def pcapstream(request, task_id, conntuple):
 
     if enabledconf["mongodb"]:
         conndata = results_db.analysis.find_one({ "info.id": int(task_id) },
-            { "network.tcp": 1, "network.udp": 1},
+            { "network.tcp": 1, "network.udp": 1, "network.sorted_pcap_sha256": 1},
             sort=[("_id", pymongo.DESCENDING)])
 
     if enabledconf["elasticsearchdb"]:


### PR DESCRIPTION
This fixes a bug which causes the hexdump JS to silently fail and not show the hex display in the network section (tcp/udp). In a future PR I'll have Django actually display an error message/traceback.