### PR TITLE
Work around for bytes/string bug in latest pefile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ elasticsearch
 java-random
 python-whois
 bs4
+http://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz#egg=pefile
 git+https://github.com/crackinglandia/pype32.git
 git+https://github.com/jsocol/django-ratelimit
 git+https://github.com/kbandla/pydeep.git


### PR DESCRIPTION
As a workaround for: #89, #103 and #136 specify which pefile to use in requirements.txt