### PR TITLE
Make API responses consistent

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -83,6 +83,7 @@ def tasks_create_file():
                                           machine=machine, platform=platform, custom=custom, memory=memory, enforce_timeout=enforce_timeout, tags=tags, clock=clock,
                                           shrike_url=shrike_url, shrike_msg=shrike_msg, shrike_sid=shrike_sid, shrike_refer=shrike_refer)
     response["task_ids"] = task_ids
+    response["task_id"] = task_ids[0]
     return jsonize(response)
 
 @route("/tasks/create/url", method="POST")
@@ -132,6 +133,7 @@ def tasks_create_url():
     )
 
     response["task_id"] = task_id
+    esponse["task_id"] = task_ids[0]
     return jsonize(response)
 
 @route("/tasks/list", method="GET")

--- a/utils/api.py
+++ b/utils/api.py
@@ -83,7 +83,6 @@ def tasks_create_file():
                                           machine=machine, platform=platform, custom=custom, memory=memory, enforce_timeout=enforce_timeout, tags=tags, clock=clock,
                                           shrike_url=shrike_url, shrike_msg=shrike_msg, shrike_sid=shrike_sid, shrike_refer=shrike_refer)
     response["task_ids"] = task_ids
-    response["task_id"] = task_ids[0]
     return jsonize(response)
 
 @route("/tasks/create/url", method="POST")
@@ -133,7 +132,6 @@ def tasks_create_url():
     )
 
     response["task_id"] = task_id
-    esponse["task_id"] = task_ids[0]
     return jsonize(response)
 
 @route("/tasks/list", method="GET")


### PR DESCRIPTION
This is a resubmission of PR #160, after GitHub for Mac messed up my
commits:

- Responses should always contain the error flag
- Response data should always be contained within the data key
- Empty search results should return an empty list
- Generate an error when requesting IOCs for a non-existent task (Fixes
HTTP 500 error)
- ~~Return single `task_id` along with the `task_ids` list in legacy `utils/api.py` as (closed source)
third party apps expect it to work like upstream Cuckoo~~