### PR TITLE
if no iocs, no create empty event

### DIFF
--- a/modules/reporting/misp.py
+++ b/modules/reporting/misp.py
@@ -90,9 +90,7 @@ class MISP(Report):
         analysis = int(self.options.get("analysis", 2))
 
         comment = "{} {}".format(results.get('info', {}).get('id'))
-
-        event = self.misp.new_event(distribution, threat_level_id, analysis, comment, date=datetime.now().strftime('%Y-%m-%d'), published=True)
-
+        
         iocs = deque()
         filtered_iocs = deque()
         threads_list = list()
@@ -151,6 +149,9 @@ class MISP(Report):
                         filtered_iocs.append(regkey)
 
         if iocs:
+          
+            event = self.misp.new_event(distribution, threat_level_id, analysis, comment, date=datetime.now().strftime('%Y-%m-%d'), published=True)
+          
             for thread_id in xrange(int(self.threads)):
                 thread = threading.Thread(target=self.cuckoo2misp_thread, args=(iocs, event))
                 thread.daemon = True


### PR DESCRIPTION
misp - fix to not create event before iocs prepared, as if analysis failed, or sample not executed correctly there no iocs, and we will get a empty event