### PR TITLE
Fixing pip install -r requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ markupsafe
 libvirt-python 
 pymongo
 bottle
-pefile
+#pefile
 django
 chardet
 pygal
@@ -24,7 +24,8 @@ elasticsearch
 java-random
 python-whois
 bs4
+http://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz#egg=pefile
 git+https://github.com/crackinglandia/pype32.git
 git+https://github.com/jsocol/django-ratelimit
 git+https://github.com/kbandla/pydeep.git
-#http://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz#egg=pefile
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ elasticsearch
 java-random
 python-whois
 bs4
-http://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz#egg=pefile
 git+https://github.com/crackinglandia/pype32.git
 git+https://github.com/jsocol/django-ratelimit
 git+https://github.com/kbandla/pydeep.git
+#http://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz#egg=pefile


### PR DESCRIPTION
double requirement of PE file fixed.
normal pip install pefile is sufficient. no extra googlecode repo necessary.