### PR TITLE
Allow for sample-download with encrypted zip

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -136,3 +136,8 @@ ids_files = no
 dropped = no
 registry = no
 mutexes = no
+
+[zipdownload]
+enabled = no
+password = infected
+deletezip = yes

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -817,7 +817,7 @@ def file(request, category, task_id, dlfile):
         path = os.path.join(CUCKOO_ROOT, "storage", "binaries", dlfile)
         #create zip file for download
         if enabledconf["zipdownload"]:
-            file_name = createEncZip(path, file_name, zippassword)
+            file_name = create_enc_zip(path, file_name, zippassword)
             path += ".zip"
             zipfile = True
         else:
@@ -900,7 +900,7 @@ def file(request, category, task_id, dlfile):
     
     return resp
 
-def createEncZip(path, file_name, password):
+def create_enc_zip(path, file_name, password):
     passparam = ''
     try:
         #set password if set in config

--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -806,6 +806,12 @@ def file(request, category, task_id, dlfile):
         "memdump" : ".dmp",
         "memdumpstrings" : ".dmp.strings",
     }
+    
+    if enabledconf["zipdownload"]:
+        zippassword = Config("reporting").zipdownload.password
+        deletezip = Config("reporting").zipdownload.deletezip
+
+
 
     if category == "sample":
         path = os.path.join(CUCKOO_ROOT, "storage", "binaries", dlfile)


### PR DESCRIPTION
Allow users to download samples as encrypted zip.
Function may be used for other downloads as well.

Change settings in reporting.conf to configure download options.

also see discussion in #206 