### PR TITLE
Fix traceback in static analysis module with recent version of pefile

### DIFF
--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -342,7 +342,14 @@ class PortableExecutable(object):
             return None
 
         if hasattr(self.pe, "DIRECTORY_ENTRY_EXPORT"):
-            return convert_to_printable(self.pe.get_string_at_rva(self.pe.DIRECTORY_ENTRY_EXPORT.struct.Name))
+            dllname = self.pe.get_string_at_rva(self.pe.DIRECTORY_ENTRY_EXPORT.struct.Name)
+            # In recent versions of pefile, get_string_at_rva returns a Python3-style bytes object.
+            # Convert it to a Python2-style string to ensure expected behavior when iterating
+            # through it character by character.
+            if type(dllname) is not str:
+                dllname = "".join([chr(c) for c in dllname])
+
+            return convert_to_printable(dllname)
         return None
 
     def _get_exported_symbols(self):


### PR DESCRIPTION
Fix for issue #103.  This will make things work with both the older versions and newer versions of pefile.