### PR TITLE
ElasticSearch support for plain searching side by side with mongo

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -48,9 +48,11 @@ db = cuckoo
 fix_large_docs = yes
 
 # Use ElasticSearch as the "database" which powers Django.
-# NOTE: If this is enabled, MongoDB should not be enabled.
+# NOTE: If this is enabled, MongoDB should not be enabled, unless
+# search only option is set to yes. Then elastic search is only used for /search web page.
 [elasticsearchdb]
 enabled = no
+searchonly = no
 host = 127.0.0.1
 port = 9200
 # The report data is indexed in the form of {{index-yyyy.mm.dd}}

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -288,7 +288,7 @@ def cuckoo_clean():
             log.warning("Unable to drop MongoDB database: %s", mdb)
 
     # Check if ElasticSearch is enabled and delete that data if it is.
-    if cfg.elasticsearchdb and cfg.elasticsearchdb.enabled:
+    if cfg.elasticsearchdb and cfg.elasticsearchdb.enabled and not cfg.elasticsearchdb.searchonly:
         from elasticsearch import Elasticsearch
         delidx = cfg.elasticsearchdb.index + "-*"
         try:

--- a/modules/reporting/retention.py
+++ b/modules/reporting/retention.py
@@ -34,7 +34,7 @@ if cfg.mongodb and cfg.mongodb.enabled:
     except Exception as e:
         log.warning("Unable to connect to MongoDB: %s", str(e))
 
-if cfg.elasticsearchdb and cfg.elasticsearchdb.enabled:
+if cfg.elasticsearchdb and cfg.elasticsearchdb.enabled and not cfg.elasticsearchdb.searchonly:
     from elasticsearch import Elasticsearch
     idx = cfg.elasticsearchdb.index + "-*"
     try:
@@ -203,7 +203,7 @@ class Retention(Report):
                             if cfg.mongodb and cfg.mongodb.enabled:
                                 delete_mongo_data(curtask, lastTask)
                         elif item == "elastic":
-                            if cfg.elasticsearchdb and cfg.elasticsearchdb.enabled:
+                            if cfg.elasticsearchdb and cfg.elasticsearchdb.enabled and not cfg.elasticsearchdb.searchonly:
                                 delete_elastic_data(curtask, lastTask)
                     saveTaskLogged[item] = int(lastTask)
                 else:

--- a/utils/dist.py
+++ b/utils/dist.py
@@ -1015,6 +1015,7 @@ def create_app(database_connection):
     return app
 
 # init 
+logging.getLogger("elasticsearch").setLevel(logging.WARNING)
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 log = logging.getLogger("cuckoo.distributed")

--- a/utils/process.py
+++ b/utils/process.py
@@ -29,7 +29,7 @@ if repconf.mongodb.enabled:
     from pymongo import MongoClient
     from pymongo.errors import ConnectionFailure
 
-if repconf.elasticsearchdb.enabled:
+if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
     from elasticsearch import Elasticsearch
     baseidx = repconf.elasticsearchdb.index
     fullidx = baseidx + "-*"
@@ -74,7 +74,7 @@ def process(target=None, copy_path=None, task=None, report=False, auto=False):
             conn.close()
             log.debug("Deleted previous MongoDB data for Task %s" % task_id)
 
-        if repconf.elasticsearchdb.enabled:
+        if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
             analyses = es.search(
                            index=fullidx,
                            doc_type="analysis",

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -42,7 +42,7 @@ if repconf.mongodb.enabled:
                      settings.MONGO_PORT
                  )[settings.MONGO_DB]
 
-if repconf.elasticsearchdb.enabled:
+if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
     from elasticsearch import Elasticsearch
     baseidx = repconf.elasticsearchdb.index
     fullidx = baseidx + "-*"
@@ -886,7 +886,7 @@ def ext_tasks_search(request):
                         "error_value": "Invalid Option. '%s' is not a valid option." % option}
                 return jsonize(resp, response=True)
 
-        if repconf.elasticsearchdb.enabled:
+        if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
             if term == "name":
                 records = es.search(index=fullidx, doc_type="analysis", q="target.file.name: %s" % value)["hits"]["hits"]
             elif term == "type":
@@ -959,7 +959,7 @@ def ext_tasks_search(request):
             for results in records:
                 if repconf.mongodb.enabled:
                     ids.append(results["info"]["id"])
-                if repconf.elasticsearchdb.enabled:
+                if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
                     ids.append(results["_source"]["info"]["id"])
             resp = {"error": False, "data": ids}
         else:
@@ -1296,7 +1296,7 @@ def tasks_iocs(request, task_id, detail=None):
     buf = {}
     if repconf.mongodb.get("enabled") and not buf:
         buf = results_db.analysis.find_one({"info.id": int(task_id)})
-    if repconf.elasticsearchdb.get("enabled") and not buf:
+    if repconf.elasticsearchdb.get("enabled") and not repconf.elasticsearchdb.get("searchonly") and not buf:
         tmp = es.search(
                   index=fullidx,
                   doc_type="analysis",

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -42,8 +42,10 @@ if repconf.mongodb.enabled:
                      settings.MONGO_PORT
                  )[settings.MONGO_DB]
 
+es_as_db = False
 if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
     from elasticsearch import Elasticsearch
+    es_as_db = True
     baseidx = repconf.elasticsearchdb.index
     fullidx = baseidx + "-*"
     es = Elasticsearch(
@@ -886,7 +888,7 @@ def ext_tasks_search(request):
                         "error_value": "Invalid Option. '%s' is not a valid option." % option}
                 return jsonize(resp, response=True)
 
-        if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
+        if es_as_db:
             if term == "name":
                 records = es.search(index=fullidx, doc_type="analysis", q="target.file.name: %s" % value)["hits"]["hits"]
             elif term == "type":
@@ -959,7 +961,7 @@ def ext_tasks_search(request):
             for results in records:
                 if repconf.mongodb.enabled:
                     ids.append(results["info"]["id"])
-                if repconf.elasticsearchdb.enabled and not repconf.elasticsearchdb.searchonly:
+                if es_as_db:
                     ids.append(results["_source"]["info"]["id"])
             resp = {"error": False, "data": ids}
         else:
@@ -1296,7 +1298,7 @@ def tasks_iocs(request, task_id, detail=None):
     buf = {}
     if repconf.mongodb.get("enabled") and not buf:
         buf = results_db.analysis.find_one({"info.id": int(task_id)})
-    if repconf.elasticsearchdb.get("enabled") and not repconf.elasticsearchdb.get("searchonly") and not buf:
+    if es_as_db and not buf:
         tmp = es.search(
                   index=fullidx,
                   doc_type="analysis",

--- a/web/compare/views.py
+++ b/web/compare/views.py
@@ -28,7 +28,9 @@ if enabledconf["mongodb"]:
 
 if enabledconf["elasticsearchdb"]:
     from elasticsearch import Elasticsearch
+    es_as_db = True
     essearch = Config("reporting").elasticsearchdb.searchonly
+    if essearch: es_as_db = False 
     baseidx = Config("reporting").elasticsearchdb.index
     fullidx = baseidx + "-*"
     es = Elasticsearch(
@@ -54,7 +56,7 @@ class conditional_login_required(object):
 def left(request, left_id):
     if enabledconf["mongodb"]:
         left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
-    if enabledconf["elasticsearchdb"] and not essearch:
+    if es_as_db:
         hits = es.search(
                    index=fullidx,
                    doc_type="analysis",
@@ -79,7 +81,7 @@ def left(request, left_id):
             },
             {"target": 1, "info": 1}
         )
-    if enabledconf["elasticsearchdb"] and not essearch:
+    if es_as_db:
         records = list()
         results = es.search(
                       index=fullidx,
@@ -98,7 +100,7 @@ def left(request, left_id):
 def hash(request, left_id, right_hash):
     if enabledconf["mongodb"]:
         left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
-    if enabledconf["elasticsearchdb"] and not essearch:
+    if es_as_db:
         hits = es.search(
                    index=fullidx,
                    doc_type="analysis",
@@ -123,7 +125,7 @@ def hash(request, left_id, right_hash):
             },
             {"target": 1, "info": 1}
         )
-    if enabledconf["elasticsearchdb"] and not essearch:
+    if es_as_db:
         records = list()
         results = es.search(
                       index=fullidx,
@@ -147,7 +149,7 @@ def both(request, left_id, right_id):
         # Execute comparison.
         counts = compare.helper_percentages_mongo(results_db, left_id, right_id)
         summary_compare = compare.helper_summary_mongo(results_db, left_id, right_id)
-    if enabledconf["elasticsearchdb"] and not essearch:
+    if es_as_db:
         left = es.search(
                    index=fullidx,
                    doc_type="analysis",

--- a/web/compare/views.py
+++ b/web/compare/views.py
@@ -28,6 +28,7 @@ if enabledconf["mongodb"]:
 
 if enabledconf["elasticsearchdb"]:
     from elasticsearch import Elasticsearch
+    essearch = Config("reporting").elasticsearchdb.searchonly
     baseidx = Config("reporting").elasticsearchdb.index
     fullidx = baseidx + "-*"
     es = Elasticsearch(
@@ -53,7 +54,7 @@ class conditional_login_required(object):
 def left(request, left_id):
     if enabledconf["mongodb"]:
         left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
-    if enabledconf["elasticsearchdb"]:
+    if enabledconf["elasticsearchdb"] and not essearch:
         hits = es.search(
                    index=fullidx,
                    doc_type="analysis",
@@ -78,7 +79,7 @@ def left(request, left_id):
             },
             {"target": 1, "info": 1}
         )
-    if enabledconf["elasticsearchdb"]:
+    if enabledconf["elasticsearchdb"] and not essearch:
         records = list()
         results = es.search(
                       index=fullidx,
@@ -97,7 +98,7 @@ def left(request, left_id):
 def hash(request, left_id, right_hash):
     if enabledconf["mongodb"]:
         left = results_db.analysis.find_one({"info.id": int(left_id)}, {"target": 1, "info": 1})
-    if enabledconf["elasticsearchdb"]:
+    if enabledconf["elasticsearchdb"] and not essearch:
         hits = es.search(
                    index=fullidx,
                    doc_type="analysis",
@@ -122,7 +123,7 @@ def hash(request, left_id, right_hash):
             },
             {"target": 1, "info": 1}
         )
-    if enabledconf["elasticsearchdb"]:
+    if enabledconf["elasticsearchdb"] and not essearch:
         records = list()
         results = es.search(
                       index=fullidx,
@@ -146,7 +147,7 @@ def both(request, left_id, right_id):
         # Execute comparison.
         counts = compare.helper_percentages_mongo(results_db, left_id, right_id)
         summary_compare = compare.helper_summary_mongo(results_db, left_id, right_id)
-    if enabledconf["elasticsearchdb"]:
+    if enabledconf["elasticsearchdb"] and not essearch:
         left = es.search(
                    index=fullidx,
                    doc_type="analysis",

--- a/web/submission/urls.py
+++ b/web/submission/urls.py
@@ -7,5 +7,5 @@ from submission import views
 
 urlpatterns = [
     url(r"^$", views.index, name='submission'),
-    url(r"status/(?P<task_id>\d+)/$", views.status),
+    url(r"status/(?P<task_id>\d+)/$", views.status, name='submission_status'),
 ]

--- a/web/templates/analysis/index.html
+++ b/web/templates/analysis/index.html
@@ -95,7 +95,7 @@
                             {% if analysis.status == "reported" %}
                                 <a href="{% url "report" analysis.id %}"><span class="mono">{{analysis.sample.md5}}</span></a>
                             {% elif analysis.status == "running" or analysis.status == "completed" %}
-                                <a href="{% url "submission.views.status" analysis.id %}"><span class="mono">{{analysis.sample.md5}}</span></a>
+                                <a href="{% url "submission_status" analysis.id %}"><span class="mono">{{analysis.sample.md5}}</span></a>
                             {% else %}
                                 <span class="mono">{{analysis.sample.md5}}</span>
                             {% endif %}
@@ -364,7 +364,7 @@
                             {% if analysis.status == "reported" %}
                                 <a href="{% url "report" analysis.id %}"><span class="mono">{{analysis.target}}</span></a>
                             {% elif analysis.status == "running" or analysis.status == "completed" %}
-                                <a href="{% url "submission.views.status" analysis.id %}"><span class="mono">{{analysis.target}}</span></a>
+                                <a href="{% url "submission_status" analysis.id %}"><span class="mono">{{analysis.target}}</span></a>
                             {% else %}
                                 <span class="mono">{{analysis.target}}</span>
                             {% endif %}
@@ -617,7 +617,7 @@
                         {% if analysis.status == "reported" %}
                         <a href="{% url "report" analysis.id %}"><span class="mono">{{analysis.sample.md5}}</span></a>
                         {% elif analysis.status == "running" or analysis.status == "completed" %}
-                        <a href="{% url "submission.views.status" analysis.id %}"><span class="mono">{{analysis.sample.md5}}</span></a>
+                        <a href="{% url "submission_status" analysis.id %}"><span class="mono">{{analysis.sample.md5}}</span></a>
                         {% else %}
                         <span class="mono">{{analysis.sample.md5}}</span>
                         {% endif %}

--- a/web/templates/analysis/search.html
+++ b/web/templates/analysis/search.html
@@ -14,6 +14,7 @@
             <button type="submit" class="btn btn-primary">Search</button>
         </form>
         <div id="help" class="collapse">
+            <p class="text-muted" style="margin-top: 10px;">ElasticSearch queries do not use a prefix. ie: '*windows.*' would match 'time.windows.com'</p>
             <p class="text-muted" style="margin-top: 10px;">For MD5, SHA1, SHA256 and SHA512 no prefix is needed.</p>
             <table class="table table-striped table-centered">
                 <thead>

--- a/web/templates/submission/complete.html
+++ b/web/templates/submission/complete.html
@@ -4,7 +4,7 @@
 <div class="alert alert-success"><h4>Submission complete!</h4>
 The following tasks were added successfully:
 {% for task in tasks %}
-    <a href="{% url "submission.views.status" task %}">{{task}}</a>
+    <a href="{% url "submission_status" task %}">{{task}}</a>
 {% endfor %}.
 Click on the links to monitor the status of the submission.
 </div>

--- a/web/templates/success.html
+++ b/web/templates/success.html
@@ -4,7 +4,7 @@
 <div class="alert alert-success"><h4>Submission complete!</h4>
 The following tasks were added successfully:
 {% for task in tasks %}
-    <a href="{% url "submission.views.status" task %}">{{task}}</a>
+    <a href="{% url "submission_status" task %}">{{task}}</a>
 {% endfor %}.
 Click on the links to monitor the status of the submission.
 </div>

--- a/web/web/settings.py
+++ b/web/web/settings.py
@@ -21,7 +21,8 @@ cfg = Config("reporting")
 if not cfg.mongodb.get("enabled") and not cfg.elasticsearchdb.get("enabled"):
     raise Exception("No database backend reporting module is enabled! Please enable either ElasticSearch or MongoDB.")
 
-if cfg.mongodb.get("enabled") and cfg.elasticsearchdb.get("enabled"):
+if cfg.mongodb.get("enabled") and cfg.elasticsearchdb.get("enabled") and \
+    not cfg.elasticsearchdb.get("searchonly"):
     raise Exception("Both database backend reporting modules are enabled. Please only enable ElasticSearch or MongoDB.")
 
 aux_cfg =  Config("auxiliary")


### PR DESCRIPTION
## Features
* Ability to use ElasticSearch for faster searches of analyses (compared to mongo) 
* Works on a single and distributed node setup
* Works side by side with mongo searching, mongo searches will query anything with a `prefix`, while ES can take care of queries without it. 
* ES supports entries like `*.windows*` that could match all samples with urls `time.windows.com` for example

## Summary
After having used modified-cuckoo for a while, after around 20k samples querying mongo db for searches takes quite a lot of time, where as ES can be hosted separately on a machine and optimized for fast queries. 