### PR TITLE
To patch when suricata key present but empty for some strange reason

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1355,7 +1355,7 @@ def tasks_iocs(request, task_id, detail=None):
         data["network"]["hosts"] = buf["network"]["hosts"]
         data["network"]["domains"] = buf["network"]["domains"]
     data["network"]["ids"] = {}
-    if "suricata" in buf.keys():
+    if "suricata" in buf.keys() and isinstance(buf["suricata"], dict):
         data["network"]["ids"]["totalalerts"] = len(buf["suricata"]["alerts"])
         data["network"]["ids"]["alerts"] = buf["suricata"]["alerts"]
         data["network"]["ids"]["http"] = buf["suricata"]["http"]


### PR DESCRIPTION
cat report.json | jq .suricata
[]

in this case, without patch, the ioc retrieve will be broken