### PR TITLE
Do not ignore whitespace past opening delimiter in string literals

### DIFF
--- a/lib/cuckoo/common/peepdf/PDFCore.py
+++ b/lib/cuckoo/common/peepdf/PDFCore.py
@@ -7718,7 +7718,7 @@ class PDFParser :
         else:
             delimiters = self.delimiters
         for delim in delimiters:
-            ret = self.readSymbol(content, delim[0])
+            ret = self.readSymbol(content, delim[0], False if delim[0] == '(' else True)
             if ret[0] != -1:
                 if delim[2] == 'dictionary':
                     ret = self.readUntilClosingDelim(content, delim)


### PR DESCRIPTION
Fix issue described in https://github.com/jesparza/peepdf/pull/61 which on rare occasions would cause static analysis of password-protected PDF documents to fail, and sometimes result in MongoDB reporting module tracebacks (since storage of encrypted non-UTF8 byte strings would be attempted).