### PR TITLE
Fixed a bug in web/api/views.py 

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1760,7 +1760,7 @@ def tasks_procmemory(request, task_id, pid="all"):
         resp = {"error": True, "error_value": "Method not allowed"}
         return jsonize(resp, response=True)
 
-    if not apiconf.procmemory.get("enabled"):
+    if not apiconf.taskprocmemory.get("enabled"):
         resp = {"error": True,
                 "error_value": "Process memory download API is disabled"}
         return jsonize(resp, response=True)


### PR DESCRIPTION
When checking to see if process memory was enabled, it would look for the config option apiconf.procmemory rather than apiconf.taskprocmemory.