### PR TITLE
LibVirt machinery should create the KVM domain

### DIFF
--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -392,6 +392,14 @@ class LibVirtMachinery(Machinery):
             self._disconnect(conn)
             raise CuckooMachineError("No snapshot found for virtual machine "
                                      "{0}".format(label))
+        # Attempt to boot the VM (create domain) if it's powered off
+        # This should address use of offline snapshots for fast clones/other uses.
+        if self._status(label) == self.POWEROFF:
+            try:
+                self.vms[label].create()
+            except libvirt.libvirtError:
+                raise CuckooMachineError("Unable to create domain for "
+                                         "virtual machine {0}".format(label))
 
         # Check state.
         self._wait_status(label, self.RUNNING)


### PR DESCRIPTION
Currently, LibVirt machinery can determine the snapshot and revert
the VM state to it, but it jumps straight to waiting for a state
change without actually issuing a create call to the domain being
used.

Add a single line to call self.vms[label].create() after resolving
the snapshot state and prior to entering the wait state.