### PR TITLE
README.md: add archive.org mirror to dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ It offers a number of advantages over the upstream Cuckoo:
 + Hundreds of other bugfixes
 
 For more information on the initial set of changes, see:
-http://www.accuvant.com/blog/improving-reliability-of-sandbox-results
+https://www.optiv.com/blog/improving-reliability-of-sandbox-results
 
 If you want to contribute to development, feel free to submit a pull request.


### PR DESCRIPTION
Due to the fact that the original link in the documentation went 404 i added an archive.org mirror link. It might be even better to have this documentation directly in the repository.