### PR TITLE
fix of 'Sniffer' object has no attribute 'proc'

### DIFF
--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -18,6 +18,10 @@ log = logging.getLogger(__name__)
 
 
 class Sniffer(Auxiliary):
+    def __init__(self):
+        Auxiliary.__init__(self)
+        self.proc = None
+        
     def start(self):
         # Get updated machine info
         self.machine = self.db.view_machine_by_label(self.machine.label)


### PR DESCRIPTION
WARNING: Unable to stop auxiliary module: 'Sniffer' object has no attribute 'proc'