### PR TITLE
Handle failed network capture in API

### DIFF
--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1352,7 +1352,7 @@ def tasks_iocs(request, task_id, detail=None):
             del data["target"]["file"]["path"]
             del data["target"]["file"]["guest_paths"]
     data["network"] = {}
-    if "network" in buf.keys():
+    if "network" in buf.keys() and buf["network"]:
         data["network"]["traffic"] = {}
         for netitem in ["tcp", "udp", "irc", "http", "dns", "smtp", "hosts", "domains"]:
             if netitem in buf["network"]:


### PR DESCRIPTION
If the network capture fails don't try to process network items when generating API response.